### PR TITLE
chore: update travis badge url

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,4 +46,4 @@ There are preconfigured Travis-CI tasks in the `scripts` folder for automatic de
 1. `yarn run deploy`
 
 [gulp-src]: http://gulpjs.com/
-[travis-src]: https://travis-ci.org/SenHeng/FrontEndSeed.svg?branch=master
+[travis-src]: https://travis-ci.org/thelegendofcode/FrontEndSeed.svg?branch=master


### PR DESCRIPTION
Travis badge URL wasn't updated when repo was transferred over to @thelegendofcode